### PR TITLE
Updates README.md to use new Vundle syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install
 
 With [Vundle](https://github.com/gmarik/vundle):
 
-    Bundle 'gertjanreynaert/cobalt2-vim-theme'
+    Plugin 'gertjanreynaert/cobalt2-vim-theme'
 
 For terminal vim: the only way to accomplish the background color is by
 installing the [cobalt2 iterm color


### PR DESCRIPTION
Even though Vundle still supports the old 'Bundle' syntax, it would probably be a good to switch to the new 'Plugin' syntax in your README in instructions for installing.