### PR TITLE
rename: cobalt => cobalt2

### DIFF
--- a/colors/cobalt2.vim
+++ b/colors/cobalt2.vim
@@ -10,7 +10,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let colors_name = "cobalt"
+let colors_name = "cobalt2"
 
 if has("gui_running") || &t_Co == 88 || &t_Co == 256
   let s:low_color = 0


### PR DESCRIPTION
otherwise, vim will complain: "can not find colorscheme cobalt"
